### PR TITLE
fixed ugly red warning when running dev script

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -3,9 +3,9 @@ module.exports = {
   plugins: {
     'postcss-flexbugs-fixes': {},
     'postcss-mq-keyframes': {},
-    'css-mqpacker': {sort: true},
+    'css-mqpacker': { sort: true },
     'autoprefixer': {
-      browsers: ['> 2%', 'last 6 versions', 'not ie <= 11'],
+      overrideBrowsersList: ['> 2%', 'last 6 versions', 'not ie <= 11'],
       cascade: false,
       flexbox: 'no-2009'
     },


### PR DESCRIPTION
 Before:
![before](https://user-images.githubusercontent.com/43292302/71313550-d3ea2380-2442-11ea-8a72-a6624dea85bd.png)
After:
![after](https://user-images.githubusercontent.com/43292302/71313557-faa85a00-2442-11ea-913e-1e7e810ce33e.png)